### PR TITLE
Adding equals function to gamepad state

### DIFF
--- a/state.go
+++ b/state.go
@@ -18,6 +18,18 @@ type State struct {
 	buttons uint32
 }
 
+// Equals verify if actual state is equals to another
+func (s State) Equals(state State) bool {
+	// not verifying axis length (assuming it wont change)
+	for i, ax := range s.axis {
+		if ax != state.axis[i] {
+			return false
+		}
+	}
+
+	return s.buttons == state.buttons
+}
+
 // A button is pressed
 func (s State) A() bool {
 	return s.buttons&0b_0001 > 0

--- a/state_test.go
+++ b/state_test.go
@@ -1,16 +1,15 @@
-package gamepad_test
+package gamepad
 
 import (
 	"testing"
 	"time"
 
-	"github.com/orsinium-labs/gamepad"
 	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
 	is := require.New(t)
-	g, err := gamepad.NewGamepad(1)
+	g, err := NewGamepad(1)
 	is.Nil(err)
 
 	st, err := g.State()
@@ -26,4 +25,19 @@ func Test(t *testing.T) {
 	is.False(st.B())
 	is.Equal(st.LT(), -100)
 	is.Equal(st.LS().X, 0)
+}
+
+func Test_Equals(t *testing.T) {
+	is := require.New(t)
+
+	s := State{
+		axis:    []int{0, 0},
+		buttons: 0,
+	}
+
+	is.False(s.Equals(State{[]int{1, 0}, 0}))
+	is.False(s.Equals(State{[]int{0, 1}, 0}))
+	is.False(s.Equals(State{[]int{0, 0}, 1}))
+	is.False(s.Equals(State{[]int{0, 0}, 1}))
+	is.True(s.Equals(State{[]int{0, 0}, 0}))
 }


### PR DESCRIPTION
Hi, using your library I could not find a way to compare gamepad states without using reflection. Please accept my humble changes S2.